### PR TITLE
DO NOT MERGE: control new tiled event listing packages

### DIFF
--- a/cfg/sources.cfg
+++ b/cfg/sources.cfg
@@ -27,7 +27,7 @@ auto-checkout =
     collective.contentleadimage
 
 [sources]
-dssweb.theme.magic = git git@github.com:ucdavis/dssweb.theme.magic.git
+dssweb.theme.magic = git git@github.com:ucdavis/dssweb.theme.magic.git branch=features/tiled-event-listing
 Products.FacultyStaffDirectory =  git git@github.com:ucdavis/Products.FacultyStaffDirectory.git
 Products.IssEvent = git https://github.com/CMcStone/Products.IssEvent.git
 collective.portlet.contentleadimage = git https://github.com/CMcStone/collective.portlet.contentleadimage.git
@@ -38,7 +38,7 @@ webcouturier.dropdownmenu = git https://github.com/CMcStone/webcouturier.dropdow
 collective.navrootacquisition = git  https://github.com/smcmahon/collective.navrootacquisition
 dssweb.facnavviews = git https://github.com/CMcStone/dssweb.facnavviews
 Products.DssPageTypes = git https://github.com/CMcStone/Products.DssPageTypes.git
-dss.web = git git@github.com:ucdavis/dss.web.git
+dss.web = git git@github.com:ucdavis/dss.web.git branch=features/tiled-event-listing
 collective.tinyaccordion = git https://github.com/CMcStone/collective.tinyaccordion.git
 collective.jqxgrid_pages = git https://github.com/CMcStone/collective.jqxgrid_pages.git
 dssweb.config = git https://github.com/CMcStone/dssweb.config.git


### PR DESCRIPTION
The changes present in this PR are intended to allow evaluation of the new tiled event listing.  Running this pr will pull the `features/tiled-event-listing` branches of the `dss.web` and `dssweb.theme.magic` packages.  Running the upgrade step for `dss.web` present in that branch will install and set up a view called the "Tiled event listing" suitable for use on Folders, collections and as the display for faceted search or navigation.

The view is really only suitable for collections or folders of `Events`.  The behavior of other content types is not defined, but is unlikely to be good.  

If each event has a content lead image set, then a 250x250 pixel scaling of that image will be used in the tile.  If not, a default image will appear as the background of the area in each tile where the image should be located.  Each image is linked to the event.

For related PRs, please see:

* [`dss.web`]()
* ['dssweb.theme.magic`]()
 